### PR TITLE
feat: add BigInt dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,16 @@ let package = Package(
             name: "WalletKit",
             targets: ["WalletKit"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/attaswift/BigInt.git", .upToNextMajor(from: "5.7.0")),
+    ],
     targets: [
         .target(
             name: "WalletKit",
-            dependencies: ["walletkit_coreFFI"],
+            dependencies: [
+                "walletkit_coreFFI",
+                .product(name: "BigInt", package: "BigInt"),
+            ],
             path: "Sources/WalletKit"
         ),
         .binaryTarget(


### PR DESCRIPTION
WalletKit Swift now depends on the BigInt dependency.
